### PR TITLE
fix: tooltip border fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clafrica-wish"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Wish interface for the clafrica."
 repository = "https://github.com/pythonbrad/clafrica"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,8 @@ impl api::Frontend for Wish {
     fn update_position(&mut self, position: (f64, f64)) {
         {
             let wish_obj = &self.window.id;
-            let (x, y) = position;
+            let x = (position.0 + self.border) as u64;
+            let y = (position.1 + self.border) as u64;
             rstk::tell_wish(&format!("wm geometry {wish_obj} +{x}+{y}"));
         }
     }


### PR DESCRIPTION
 The tooltip was too close to the mouse, resulting in the program closing when the tooltip was clicked. The fix involves adjusting the positioning of the tooltip to prevent it from overlapping with the mouse.